### PR TITLE
Fix vscode settings for python interpreter and venv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,6 +35,7 @@
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
 				"workbench": {
 					"editorAssociations": {
 						"*.md": "vscode.markdown.preview.editor"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,6 +36,7 @@
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.createEnvironment.trigger": "off",
 				"workbench": {
 					"editorAssociations": {
 						"*.md": "vscode.markdown.preview.editor"


### PR DESCRIPTION
Here we:
- define Python interpreter to use (from the `ocean-dev` image) - bring up to date with `ocean-dev` metadata. Close #2.
- turn off vscode notification to create a virtual env (it's confusing because venv is not needed if ocean-dev image is used). Close #4.